### PR TITLE
Use Cacofonix::DTDs before reading XML files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :gemcutter
+source "https://rubygems.org"
 
 gemspec

--- a/lib/onix/core/reader.rb
+++ b/lib/onix/core/reader.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 require 'stringio'
+require "cacofonix/dtds"
 
 module ONIX
 
@@ -114,9 +115,11 @@ module ONIX
     private
 
     def create_parser
+      Cacofonix::DTDs.apply_libxml_env!
+
       parser_config = lambda { |cfg|
         cfg.noent
-        cfg.dtdload  unless @options[:dtd] == false
+        cfg.dtdload unless @options[:dtd] == false
       }
       if @input.kind_of?(String)
         @file   = File.open(@input, "r")

--- a/onix.gemspec
+++ b/onix.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport')
   s.add_dependency('i18n')
   s.add_dependency('nokogiri')
+  s.add_dependency "cacofonix-dtds", "~> 0.1"
 
   s.add_development_dependency("rake")
   s.add_development_dependency('rdoc')


### PR DESCRIPTION
This is necessary now that the original DTDs are no longer online