### PR TITLE
Fix deprecations

### DIFF
--- a/lib/onix/core/code.rb
+++ b/lib/onix/core/code.rb
@@ -8,7 +8,7 @@ module ONIX
     attr_reader :key, :value, :list, :list_number
 
     # Note re: key type. For backwards compatibility, code keys that are
-    # all-digits are passed around in this gem as Fixnums.
+    # all-digits are passed around in this gem as Integers.
     #
     # The actual code list hashes have string-based keys for consistency. If
     # you want the integer-or-string key, use Code#key. If you want the real
@@ -28,7 +28,7 @@ module ONIX
       @key = @value = nil
       return  if data.nil? || data == ""
 
-      if data.kind_of?(Fixnum)
+      if data.kind_of?(Integer)
         @key = data
         pad_length = options[:length] || ["#{@list.size}".size, 2].max
         @real_key = pad(data, pad_length)
@@ -80,7 +80,7 @@ module ONIX
 
     private
 
-      # Converts a Fixnum key into a String key.
+      # Converts a Integer key into a String key.
       #
       def pad(key, len)
         key ? key.to_s.rjust(len, '0') : nil

--- a/lib/onix/core/header.rb
+++ b/lib/onix/core/header.rb
@@ -18,7 +18,7 @@ module ONIX
     xml_accessor :to_company,      :from => "ToCompany"
     xml_accessor :to_person,       :from => "ToPerson"
     xml_accessor :message_number,  :from => "MessageNumber"
-    xml_accessor :message_repeat,  :from => "MessageRepeat", :as => Fixnum
+    xml_accessor :message_repeat,  :from => "MessageRepeat", :as => Integer
     xml_accessor(:sent_date,       :from => "SentDate", :to_xml => ONIX::Formatters.yyyymmdd) do |val|
       begin
         Date.parse(val)
@@ -30,7 +30,7 @@ module ONIX
 
     # defaults
     xml_accessor  :default_language_of_text, :from => "DefaultLanguageOfText"
-    xml_accessor  :default_price_type_code, :from => "DefaultPriceTypeCode", :as => Fixnum, :to_xml => ONIX::Formatters.two_digit
+    xml_accessor  :default_price_type_code, :from => "DefaultPriceTypeCode", :as => Integer, :to_xml => ONIX::Formatters.two_digit
     xml_accessor  :default_currency_code,   :from => "DefaultCurrencyCode"
     xml_reader    :default_linear_unit,     :from => "DefaultLinearUnit"        # deprecated in ONIX spec
     xml_reader    :default_weight_unit,     :from => "DefaultWeightUnit"        # deprecated in ONIX spec

--- a/lib/onix/core/reader.rb
+++ b/lib/onix/core/reader.rb
@@ -137,7 +137,7 @@ module ONIX
         if @reader.node_type == 1 && @reader.name == "ONIXMessage"
           value = @reader.attributes["release"]
           if value
-            return BigDecimal.new(value)
+            return BigDecimal(value)
           else
             return nil
           end

--- a/lib/onix/elements/audience_range.rb
+++ b/lib/onix/elements/audience_range.rb
@@ -4,7 +4,7 @@ class ONIX::AudienceRange < ONIX::Element
   xml_name "AudienceRange"
   onix_code_from_list :audience_range_qualifier, "AudienceRangeQualifier", :list => 30
   onix_codes_from_list :audience_range_precisions, "AudienceRangePrecision", :list => 31
-  xml_accessor :audience_range_values, :from => "AudienceRangeValue", :as => [Fixnum]
+  xml_accessor :audience_range_values, :from => "AudienceRangeValue", :as => [Integer]
   # TODO: element AudienceRange: validity error :
   #   Element AudienceRange content does not follow the DTD, expecting
   #   (AudienceRangeQualifier , AudienceRangePrecision , AudienceRangeValue ,

--- a/lib/onix/elements/batch_bonus.rb
+++ b/lib/onix/elements/batch_bonus.rb
@@ -2,6 +2,6 @@
 
 class ONIX::BatchBonus < ONIX::Element
   xml_name "BatchBonus"
-  xml_accessor :batch_quantity, :from => "BatchQuantity", :as => Fixnum
-  xml_accessor :free_quantity, :from => "FreeQuantity", :as => Fixnum
+  xml_accessor :batch_quantity, :from => "BatchQuantity", :as => Integer
+  xml_accessor :free_quantity, :from => "FreeQuantity", :as => Integer
 end

--- a/lib/onix/elements/contained_item.rb
+++ b/lib/onix/elements/contained_item.rb
@@ -2,5 +2,5 @@
 
 class ONIX::ContainedItem < ONIX::ProductBase
   xml_name "ContainedItem"
-  xml_accessor :item_quantity, :from => "ItemQuantity", :as => Fixnum
+  xml_accessor :item_quantity, :from => "ItemQuantity", :as => Integer
 end

--- a/lib/onix/elements/contributor.rb
+++ b/lib/onix/elements/contributor.rb
@@ -2,10 +2,10 @@
 
 class ONIX::Contributor < ONIX::NameBase
   xml_name "Contributor"
-  xml_accessor :sequence_number, :from => "SequenceNumber", :as => Fixnum
+  xml_accessor :sequence_number, :from => "SequenceNumber", :as => Integer
   onix_code_from_list :contributor_role, "ContributorRole", :list => 17
   onix_code_from_list :language_code, "LanguageCode", :list => 74
-  xml_accessor :sequence_number_within_role, :from => "SequenceNumberWithinRole", :as => Fixnum
+  xml_accessor :sequence_number_within_role, :from => "SequenceNumberWithinRole", :as => Integer
   onix_composite :names, ONIX::Name
   onix_composite :person_dates, ONIX::PersonDate
   onix_composite :professional_affiliations, ONIX::ProfessionalAffiliation

--- a/lib/onix/elements/copyright_statement.rb
+++ b/lib/onix/elements/copyright_statement.rb
@@ -2,6 +2,6 @@
 
 class ONIX::CopyrightStatement < ONIX::Element
   xml_name "CopyrightStatement"
-  xml_accessor :copyright_years, :from => "CopyrightYear", :as => [Fixnum]
+  xml_accessor :copyright_years, :from => "CopyrightYear", :as => [Integer]
   onix_composite :copyright_owners, ONIX::CopyrightOwner
 end

--- a/lib/onix/elements/illustrations.rb
+++ b/lib/onix/elements/illustrations.rb
@@ -4,5 +4,5 @@ class ONIX::Illustrations < ONIX::Element
   xml_name "Illustrations"
   onix_code_from_list :illustration_type, "IllustrationType", :list => 25
   xml_accessor :illustration_type_description, :from => "IllustrationTypeDescription"
-  xml_accessor :number, :from => "Number", :as => Fixnum
+  xml_accessor :number, :from => "Number", :as => Integer
 end

--- a/lib/onix/elements/on_order_detail.rb
+++ b/lib/onix/elements/on_order_detail.rb
@@ -2,6 +2,6 @@
 
 class ONIX::OnOrderDetail < ONIX::Element
   xml_name "OnOrderDetail"
-  xml_accessor :on_order, :from => "OnOrder", :as => Fixnum
+  xml_accessor :on_order, :from => "OnOrder", :as => Integer
   onix_date_accessor :expected_date, "ExpectedDate"
 end

--- a/lib/onix/elements/price.rb
+++ b/lib/onix/elements/price.rb
@@ -19,7 +19,7 @@ module ONIX
     onix_code_from_list :price_type_qualifier, "PriceTypeQualifier", :list => 59
     xml_accessor :price_type_description, :from => "PriceTypeDescription"
     onix_code_from_list :price_per, "PricePer", :list => 60
-    xml_accessor :minimum_order_qty, :from => "MinimumOrderQuantity", :as => Fixnum
+    xml_accessor :minimum_order_qty, :from => "MinimumOrderQuantity", :as => Integer
     onix_composite :batch_bonuses, ONIX::BatchBonus
     xml_accessor :class_of_trade, :from => "ClassOfTradeCode"
     xml_accessor :bic_discount_group_code, :from => "BICDiscountGroupCode"

--- a/lib/onix/elements/product.rb
+++ b/lib/onix/elements/product.rb
@@ -38,7 +38,7 @@ class ONIX::Product < ONIX::ProductBase
   onix_composite :work_identifiers, ONIX::WorkIdentifier
   onix_code_from_list :thesis_type, "ThesisType", :list => 72
   xml_accessor :thesis_presented_to, :from => "ThesisPresentedTo"
-  xml_accessor :year_of_thesis, :from => "YearOfThesis", :as => Fixnum
+  xml_accessor :year_of_thesis, :from => "YearOfThesis", :as => Integer
 
   # PR.8 Authorship
   onix_composite :contributors, ONIX::Contributor
@@ -50,7 +50,7 @@ class ONIX::Product < ONIX::ProductBase
 
   # PR.10 Edition
   onix_code_from_list :edition_type_code, "EditionTypeCode", :list => 21
-  xml_accessor :edition_number, :from => "EditionNumber", :as => Fixnum
+  xml_accessor :edition_number, :from => "EditionNumber", :as => Integer
   xml_accessor :edition_version_number, :from => "EditionVersionNumber"
   xml_accessor :edition_statement, :from => "EditionStatement"
   onix_boolean_flag(:no_edition, "NoEdition")
@@ -60,14 +60,14 @@ class ONIX::Product < ONIX::ProductBase
   onix_composite :languages, ONIX::Language
 
   # PR.12 Extents and other content
-  xml_accessor :number_of_pages, :from => "NumberOfPages", :as => Fixnum
+  xml_accessor :number_of_pages, :from => "NumberOfPages", :as => Integer
   xml_accessor :pages_roman, :from => "PagesRoman"
-  xml_accessor :pages_arabic, :from => "PagesArabic", :as => Fixnum
+  xml_accessor :pages_arabic, :from => "PagesArabic", :as => Integer
   onix_composite :extents, ONIX::Extent
-  xml_accessor :number_of_illustrations, :from => "NumberOfIllustrations", :as => Fixnum
+  xml_accessor :number_of_illustrations, :from => "NumberOfIllustrations", :as => Integer
   xml_accessor :illustrations_note, :from => "IllustrationsNote"
   onix_composite :illustrations, ONIX::Illustrations
-  xml_accessor :map_scale, :from => "MapScale", :as => [Fixnum]
+  xml_accessor :map_scale, :from => "MapScale", :as => [Integer]
 
   # PR.13 Subject
   xml_accessor :basic_main_subject, :from => "BASICMainSubject"
@@ -115,8 +115,8 @@ class ONIX::Product < ONIX::ProductBase
   onix_date_accessor :trade_announcement_date, "TradeAnnouncementDate"
   onix_date_accessor :publication_date, "PublicationDate"
   onix_composite :copyright_statements, ONIX::CopyrightStatement
-  xml_accessor :copyright_year, :from => "CopyrightYear", :as => Fixnum
-  xml_accessor :year_first_published, :from => "YearFirstPublished", :as => Fixnum
+  xml_accessor :copyright_year, :from => "CopyrightYear", :as => Integer
+  xml_accessor :year_first_published, :from => "YearFirstPublished", :as => Integer
 
   # PR.21 Territorial rights and other sales restrictions
   onix_composite :sales_rights, ONIX::SalesRights

--- a/lib/onix/elements/product_base.rb
+++ b/lib/onix/elements/product_base.rb
@@ -11,7 +11,7 @@ class ONIX::ProductBase < ONIX::Element
   onix_composite :product_form_features, ONIX::ProductFormFeature
   onix_code_from_list :product_packaging, "ProductPackaging", :list => 80
   xml_accessor :product_form_description, :from => "ProductFormDescription"
-  xml_accessor :number_of_pieces, :from => "NumberOfPieces", :as => Fixnum
+  xml_accessor :number_of_pieces, :from => "NumberOfPieces", :as => Integer
   onix_code_from_list :trade_category, "TradeCategory", :list => 12
   onix_code_from_list :product_content_type, "ProductContentType", :list => 81
   onix_code_from_list :epub_type, "EpubType", :list => 10

--- a/lib/onix/elements/supply_detail.rb
+++ b/lib/onix/elements/supply_detail.rb
@@ -25,10 +25,10 @@ class ONIX::SupplyDetail < ONIX::Element
   onix_code_from_list :date_format, "DateFormat", :list => 55
   xml_accessor :expected_ship_date, :from => "ExpectedShipDate"
   onix_date_accessor :on_sale_date, "OnSaleDate"
-  xml_accessor :order_time, :from => "OrderTime", :as => Fixnum
+  xml_accessor :order_time, :from => "OrderTime", :as => Integer
   onix_composite :stocks, ONIX::Stock
   alias_accessor :stock, :stocks # back-compat
-  xml_accessor :pack_quantity, :from => "PackQuantity", :as => Fixnum
+  xml_accessor :pack_quantity, :from => "PackQuantity", :as => Integer
   onix_code_from_list :audience_restriction_flag, "AudienceRestrictionFlag", :list => 56
   xml_accessor :audience_restriction_note, :from => "AudienceRestrictionNote"
   onix_code_from_list :unpriced_item_type, "UnpricedItemType", :list => 57

--- a/lib/onix/elements/text_item.rb
+++ b/lib/onix/elements/text_item.rb
@@ -7,5 +7,5 @@ class ONIX::TextItem < ONIX::Element
   xml_accessor :first_page_number, :from => "FirstPageNumber"
   xml_accessor :last_page_number, :from => "LastPageNumber"
   onix_composite :page_runs, ONIX::PageRun
-  xml_accessor :number_of_pages, :from => "NumberOfPages", :as => Fixnum
+  xml_accessor :number_of_pages, :from => "NumberOfPages", :as => Integer
 end

--- a/lib/onix/elements/title.rb
+++ b/lib/onix/elements/title.rb
@@ -3,7 +3,7 @@
 class ONIX::Title < ONIX::Element
   xml_name "Title"
   onix_code_from_list :title_type, "TitleType", :list => 15
-  xml_accessor :abbreviated_length, :from => "AbbreviatedLength", :as => Fixnum
+  xml_accessor :abbreviated_length, :from => "AbbreviatedLength", :as => Integer
   xml_accessor :title_text, :from => "TitleText"
   xml_accessor :title_prefix, :from => "TitlePrefix"
   xml_accessor :title_without_prefix, :from => "TitleWithoutPrefix"

--- a/onix.gemspec
+++ b/onix.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.test_files        = Dir.glob("spec/**/*.rb")
   s.files             = Dir.glob("{lib,support,dtd}/**/**/*") + ["README.markdown", "TODO", "CHANGELOG"]
 
+  s.required_ruby_version = '>= 2.5'
+
   s.add_dependency('roxml', '~>4.0')
   s.add_dependency('activesupport')
   s.add_dependency('i18n')

--- a/spec/core/code_spec.rb
+++ b/spec/core/code_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper.rb'
 describe ONIX::Code, "instantiation" do
 
   it "should raise an error for an invalid codelist number" do
-    lambda { ONIX::Code.new(500, 1) }.should raise_error
+    lambda { ONIX::Code.new(500, 1) }.should raise_error(LoadError)
   end
 
   it "should find the codelist from a valid number" do

--- a/spec/core/elements_spec.rb
+++ b/spec/core/elements_spec.rb
@@ -129,7 +129,7 @@ describe ONIX::Element, "custom accessors" do
         <StrictIdentifier>This is not a valid code in the list</StrictIdentifier>
       </TestElement>
     `
-    lambda { ONIX::TestElement.from_xml(xml) }.should raise_error
+    lambda { ONIX::TestElement.from_xml(xml) }.should raise_error(ONIX::CodeNotFoundInList)
   end
 
 

--- a/spec/core/reader_spec.rb
+++ b/spec/core/reader_spec.rb
@@ -28,7 +28,7 @@ describe ONIX::Reader do
   it "should provide access to various XML metadata from file" do
     filename = find_data_file("reference_with_release_attrib.xml")
     reader = ONIX::Reader.new(filename)
-    reader.release.should eql(BigDecimal.new("2.1"))
+    reader.release.should eql(BigDecimal("2.1"))
   end
 
   it "should provide access to the header in an ONIX file" do

--- a/spec/elements/price_spec.rb
+++ b/spec/elements/price_spec.rb
@@ -17,7 +17,7 @@ describe ONIX::Price do
     p = ONIX::Price.from_xml(@root.to_s)
 
     p.price_type_code.should eql(2)
-    p.price_amount.should eql(BigDecimal.new("7.5"))
+    p.price_amount.should eql(BigDecimal("7.5"))
   end
 
   it "should provide write access to first level attributes" do
@@ -26,9 +26,8 @@ describe ONIX::Price do
     p.price_type_code = 1
     p.to_xml.to_s.include?("<PriceTypeCode>01</PriceTypeCode>").should be true
 
-    p.price_amount = BigDecimal.new("7.5")
+    p.price_amount = BigDecimal("7.5")
     p.to_xml.to_s.include?("<PriceAmount>7.5</PriceAmount>").should be true
-
   end
 
 end

--- a/spec/elements/product_spec.rb
+++ b/spec/elements/product_spec.rb
@@ -24,7 +24,7 @@ describe ONIX::Product do
 
     # including ye olde, deprecated ones
     product.height.should eql(100)
-    product.width.should eql(BigDecimal.new("200.5"))
+    product.width.should eql(BigDecimal("200.5"))
     product.weight.should eql(300)
     product.thickness.should eql(300)
     product.dimensions.should eql("100x200")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,10 @@ module ONIX::SpecInterpretations
   end
 end
 
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = :should }
+end
+
 
 RSpec::Matchers.define(:produce_the_tag) do |expected|
   match do |actual|
@@ -62,11 +66,11 @@ RSpec::Matchers.define(:include_the_xml) do |expected|
     actual.to_xml.to_s.include?(expected)
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected '#{actual.to_xml.to_s}' to include the xml '#{expected}'"
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected '#{actual.to_xml.to_s}' not to include the xml '#{expected}'"
   end
 end

--- a/spec/wrappers/apa_product_spec.rb
+++ b/spec/wrappers/apa_product_spec.rb
@@ -74,7 +74,7 @@ describe ONIX::APAProduct, "price method" do
     @product = ONIX::Product.from_xml(@product_node.to_s)
     @apa     = ONIX::APAProduct.new(@product)
 
-    @apa.price.should eql(BigDecimal.new("99.95"))
+    @apa.price.should eql(BigDecimal("99.95"))
   end
 end
 
@@ -88,6 +88,6 @@ describe ONIX::APAProduct, "rrp_exc_sales_tax method" do
     @product = ONIX::Product.from_xml(@product_node.to_s)
     @apa     = ONIX::APAProduct.new(@product)
 
-    @apa.rrp_exc_sales_tax.should eql(BigDecimal.new("99.95"))
+    @apa.rrp_exc_sales_tax.should eql(BigDecimal("99.95"))
   end
 end


### PR DESCRIPTION
Along with this, set a compatible Ruby version of 2.5 for the new BigDecimal constructor API we're using