### PR TITLE
Fix XML accessor definition bug in DiscountCoded element 

### DIFF
--- a/lib/cacofonix/elements/discount_coded.rb
+++ b/lib/cacofonix/elements/discount_coded.rb
@@ -4,5 +4,5 @@ class Cacofonix::DiscountCoded < Cacofonix::Element
   xml_name "DiscountCoded"
   onix_code_from_list :discount_code_type, "DiscountCodeType", :list => 100
   xml_accessor :discount_code_type_name, :from => "DiscountCodeTypeName"
-  xml_accessor :discount_code
+  xml_accessor :discount_code, :from => "DiscountCode"
 end


### PR DESCRIPTION
This PR fixes a bug in the DiscountCoded element definition. The XML accessor definition for the DiscountCode element was missing a `from` option. 

